### PR TITLE
Change PackagePackCommand to a final class to prevent extension

### DIFF
--- a/web/concrete/src/Console/Command/PackPackageCommand.php
+++ b/web/concrete/src/Console/Command/PackPackageCommand.php
@@ -13,7 +13,7 @@ use stdClass;
 use ZipArchive;
 use Gettext\Translations;
 
-class PackPackageCommand extends Command
+final class PackPackageCommand extends Command
 {
     const PACKAGEFORMAT_LEGACY = 'legacy';
     const PACKAGEFORMAT_CURRENT = 'current';


### PR DESCRIPTION
https://github.com/concrete5/concrete5/pull/3207
